### PR TITLE
Keeping classes for Shortened Url

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* 
+/*
 * Example style!
 * You can do whatever the hell you want on your site :-)
 */
@@ -101,4 +101,8 @@ ul li:hover {
   padding:5px;
   width:10%;
   font-family:arial;
+}
+
+.tco-hidden{
+  display: none;
 }

--- a/js/twitterFetcher.js
+++ b/js/twitterFetcher.js
@@ -60,7 +60,7 @@
 
   function strip(data) {
     return data.replace(/<b[^>]*>(.*?)<\/b>/gi, function(a,s){return s;})
-        .replace(/class=".*?"|data-query-source=".*?"|dir=".*?"|rel=".*?"/gi,
+        .replace(/class="(?!(tco-hidden|tco-display|tco-ellipsis))+.*?"|data-query-source=".*?"|dir=".*?"|rel=".*?"/gi,
         '');
   }
 


### PR DESCRIPTION
As explained in https://github.com/jasonmayes/Twitter-Post-Fetcher/issues/52#issuecomment-152368663 I've made a change to avoid the removal of the classes `tco-hidden`, `tco-display` and `tco-ellipsis` in order to show / hide the different parts of the url.