### PR TITLE
Add extra author info to the dataOnly object

### DIFF
--- a/js/twitterFetcher.js
+++ b/js/twitterFetcher.js
@@ -303,11 +303,11 @@
             tweet: tweets[n].innerHTML,
             author: authors[n] ? authors[n].innerHTML : 'Unknown Author',
             author_data: {
-              profile_url: authors[n] ? authors[n].querySelector('[data-scribe="element:user_link"]').href : nil,
-              profile_image: authors[n] ? authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-1x') : nil,
-              profile_image_2x: authors[n] ? authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-2x') : nil,
-              screen_name: authors[n] ? authors[n].querySelector('[data-scribe="element:screen_name"]').title : nil,
-              name: authors[n] ? authors[n].querySelector('[data-scribe="element:name"]').title : nil
+              profile_url: authors[n] ? authors[n].querySelector('[data-scribe="element:user_link"]').href : null,
+              profile_image: authors[n] ? authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-1x') : null,
+              profile_image_2x: authors[n] ? authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-2x') : null,
+              screen_name: authors[n] ? authors[n].querySelector('[data-scribe="element:screen_name"]').title : null,
+              name: authors[n] ? authors[n].querySelector('[data-scribe="element:name"]').title : null
             },
             time: times[n].textContent,
             timestamp: times[n].getAttribute('datetime').replace('+0000', 'Z').replace(/([\+\-])(\d\d)(\d\d)/, '$1$2:$3'),

--- a/js/twitterFetcher.js
+++ b/js/twitterFetcher.js
@@ -304,7 +304,8 @@
             author: authors[n] ? authors[n].innerHTML : 'Unknown Author',
             author_data: {
               profile_url: authors[n].querySelector('[data-scribe="element:user_link"]').href,
-              profile_image: authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-2x'),
+              profile_image: authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-1x'),
+              profile_image_2x: authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-2x'),
               screen_name: authors[n].querySelector('[data-scribe="element:screen_name"]').title,
               name: authors[n].querySelector('[data-scribe="element:name"]').title
             },

--- a/js/twitterFetcher.js
+++ b/js/twitterFetcher.js
@@ -304,6 +304,7 @@
             author: authors[n] ? authors[n].innerHTML : 'Unknown Author',
             author_data: {
               profile_url: authors[n].querySelector('[data-scribe="element:user_link"]').href,
+              profile_image: authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-2x'),
               screen_name: authors[n].querySelector('[data-scribe="element:screen_name"]').title,
               name: authors[n].querySelector('[data-scribe="element:name"]').title
             },

--- a/js/twitterFetcher.js
+++ b/js/twitterFetcher.js
@@ -303,11 +303,11 @@
             tweet: tweets[n].innerHTML,
             author: authors[n] ? authors[n].innerHTML : 'Unknown Author',
             author_data: {
-              profile_url: authors[n].querySelector('[data-scribe="element:user_link"]').href,
-              profile_image: authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-1x'),
-              profile_image_2x: authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-2x'),
-              screen_name: authors[n].querySelector('[data-scribe="element:screen_name"]').title,
-              name: authors[n].querySelector('[data-scribe="element:name"]').title
+              profile_url: authors[n] ? authors[n].querySelector('[data-scribe="element:user_link"]').href : nil,
+              profile_image: authors[n] ? authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-1x') : nil,
+              profile_image_2x: authors[n] ? authors[n].querySelector('[data-scribe="element:avatar"]').getAttribute('data-src-2x') : nil,
+              screen_name: authors[n] ? authors[n].querySelector('[data-scribe="element:screen_name"]').title : nil,
+              name: authors[n] ? authors[n].querySelector('[data-scribe="element:name"]').title : nil
             },
             time: times[n].textContent,
             timestamp: times[n].getAttribute('datetime').replace('+0000', 'Z').replace(/([\+\-])(\d\d)(\d\d)/, '$1$2:$3'),

--- a/js/twitterFetcher.js
+++ b/js/twitterFetcher.js
@@ -302,6 +302,11 @@
           arrayTweets.push({
             tweet: tweets[n].innerHTML,
             author: authors[n] ? authors[n].innerHTML : 'Unknown Author',
+            author_data: {
+              profile_url: authors[n].querySelector('[data-scribe="element:user_link"]').href,
+              screen_name: authors[n].querySelector('[data-scribe="element:screen_name"]').title,
+              name: authors[n].querySelector('[data-scribe="element:name"]').title
+            },
             time: times[n].textContent,
             timestamp: times[n].getAttribute('datetime').replace('+0000', 'Z').replace(/([\+\-])(\d\d)(\d\d)/, '$1$2:$3'),
             image: extractImageUrl(images[n]),


### PR DESCRIPTION
At the moment the dataOnly version returns an `author` attribute containing an awkward HTML string. This update includes discrete attributes for the author's `name`, `screen_name` and `profile_url`. It adds to the existing data structure without altering it for any users who already depend on the existing `author` attribute.

PS: Love this tool, and no stress if this change doesn't suit for whatever reason 👍 

PPS: This commit currently only edits the standard JS file, not the minified file