### PR TITLE
Add tweetText to tweet object

### DIFF
--- a/js/twitterFetcher.js
+++ b/js/twitterFetcher.js
@@ -321,6 +321,7 @@
         while (n < x) {
           arrayTweets.push({
             tweet: tweets[n].innerHTML,
+            tweetText: tweets[n].textContent,
             author: authors[n] ? authors[n].innerHTML : 'Unknown Author',
             author_data: {
               profile_url: authors[n] ? authors[n].querySelector('[data-scribe="element:user_link"]').href : null,


### PR DESCRIPTION
When the dataOnly parameter is set to true, make the tweet content
available as a string in a new property called tweetText.

In my use case, I wanted to truncate the tweet content, which was easier to do with a string with hyperlinks stripped out as is the case when the enableLinks parameter is set to false.